### PR TITLE
CREATE処理のテスト実装

### DIFF
--- a/src/main/java/com/u1/user/entity/User.java
+++ b/src/main/java/com/u1/user/entity/User.java
@@ -13,6 +13,7 @@ public class User {
         this.birthday = birthday;
     }
 
+
     public static User createUser(String name, String birthday) {
         return new User(null, name, birthday);
     }
@@ -53,4 +54,6 @@ public class User {
     public int hashCode() {
         return Objects.hash(id, name, birthday);
     }
+
+
 }

--- a/src/test/java/com/u1/user/integrationtest/UserIntegrationTest.java
+++ b/src/test/java/com/u1/user/integrationtest/UserIntegrationTest.java
@@ -3,6 +3,7 @@ package com.u1.user.integrationtest;
 import com.github.database.rider.core.api.dataset.DataSet;
 import com.github.database.rider.core.api.dataset.ExpectedDataSet;
 import com.github.database.rider.spring.api.DBRider;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
@@ -23,152 +24,160 @@ public class UserIntegrationTest {
     @Autowired
     MockMvc mockMvc;
 
-    @Test
-    @DataSet(value = "datasets/users.yml")
-    @Transactional
-    void 全てのユーザー取得できること() throws Exception {
-        mockMvc.perform(MockMvcRequestBuilders.get("/users"))
-                .andExpect(MockMvcResultMatchers.status().isOk())
-                //レスポンスボディの検証
-                .andExpect(MockMvcResultMatchers.content().json(
-                        //text block便利！
-                        """
-                                [
-                                     {
-                                         "id": 1,
-                                         "name": "yuichi",
-                                         "birthday": "1984-07-03"
-                                     },
-                                     {
-                                         "id": 2,
-                                         "name": "kana",
-                                         "birthday": "1993-12-31"
-                                     }
-                                ]
-                                """
-                ));
+    @Nested
+    class readClass {
 
-    }
-
-    @Test
-    @DataSet(value = "datasets/users.yml")
-    @Transactional
-    void 指定したIDで存在するユーザーを取得すること() throws Exception {
-        mockMvc.perform(MockMvcRequestBuilders.get("/users/1"))
-                .andExpect(MockMvcResultMatchers.status().isOk())
-
-                .andExpect(MockMvcResultMatchers.content().json(
-                        //text block便利！
-                        """
-                                     {
-                                         "id": 1,
-                                         "name": "yuichi",
-                                         "birthday": "1984-07-03"
-                                     }
-                                """
-                ));
-    }
-
-    @Test
-    @DataSet(value = "datasets/users.yml")
-    @Transactional
-    void 指定した名前で存在するユーザーを取得すること() throws Exception {
-        mockMvc.perform(MockMvcRequestBuilders.get("/users/names?name=y"))
-                .andExpect(MockMvcResultMatchers.status().isOk())
-                .andExpect(MockMvcResultMatchers.content().json("""
-                                        {
-                                                 "id": 1,
-                                                 "name": "yuichi",
-                                                 "birthday": "1984-07-03"
-                                        }
-                        """
-                ));
-    }
-
-    @Test
-    @DataSet(value = "datasets/users.yml")
-    @Transactional
-    void 存在しない名前を指定したとき例外処理を返すこと() throws Exception {
-
-        mockMvc.perform(MockMvcRequestBuilders.get("/users/names?name=unknownUser"))
-                .andExpect(MockMvcResultMatchers.status().isNotFound())
-                .andExpect(MockMvcResultMatchers.jsonPath("$.timestamp").exists())
-                .andExpect(MockMvcResultMatchers.jsonPath("$.status").value("404"))
-                .andExpect(MockMvcResultMatchers.jsonPath("$.error").value("Not Found"))
-                .andExpect(MockMvcResultMatchers.jsonPath("$.message").value("user not found containing name: " + "unknownUser"))
-                .andExpect(MockMvcResultMatchers.jsonPath("$.path").value("/users/names"));
-
-    }
-
-    @Test
-    @DataSet(value = "datasets/users.yml")
-    @Transactional
-    void 存在しないIDを指定したとき例外処理を返すこと() throws Exception {
-
-        mockMvc.perform(MockMvcRequestBuilders.get("/users/0"))
-                .andExpect(MockMvcResultMatchers.status().isNotFound())
-                .andExpect(MockMvcResultMatchers.jsonPath("$.timestamp").exists())
-                .andExpect(MockMvcResultMatchers.jsonPath("$.status").value("404"))
-                .andExpect(MockMvcResultMatchers.jsonPath("$.error").value("Not Found"))
-                .andExpect(MockMvcResultMatchers.jsonPath("$.message").value("user not found with id: " + 0))
-                .andExpect(MockMvcResultMatchers.jsonPath("$.path").value("/users/0"));
-
-    }
-
-    /*-------------------------------登録処理-------------------------------------------------------------------------*/
-    @Test
-    @DataSet(value = "datasets/users.yml")
-    @ExpectedDataSet(value = "datasets/insertUsers.yml", ignoreCols = "id")
-    @Transactional
-    void 名前と生年月日を未使用のIDで紐づけし登録すること() throws Exception {
-        String requestBody = """
-                {
-                           "name": "Tom",
-                           "birthday": "1990/01/01"
-                }
-                """;
-        mockMvc.perform(MockMvcRequestBuilders.post("/users")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(requestBody))
-                .andExpect(MockMvcResultMatchers.status().isCreated())
-                .andExpect(MockMvcResultMatchers.content().json("""
-                        {
-                            "message": "user created"
-                        }
-                        """));
-    }
-
-    @Test
-    @DataSet(value = "datasets/users.yml")
-    @Transactional
-    void 指定しないフォーマットで登録しようとしたとき例外処理を返すこと() throws Exception {
-        String exceptionRequestBody = """
-                {
-                           "name": "",
-                           "birthday": ""
-                }
-                """;
-        mockMvc.perform(MockMvcRequestBuilders.post("/users")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(exceptionRequestBody))
-                .andExpect(MockMvcResultMatchers.status().isBadRequest())
-                .andExpect(MockMvcResultMatchers.content().json(
-                        """
-                                {
-                                    "status": "BAD_REQUEST",
-                                    "message": "validation error",
-                                    "errors": [
-                                        {
-                                            "field": "birthday",
-                                            "message": "YYYY/MM/ddで入力して下さい"
-                                        },
-                                        {
-                                            "field": "name",
-                                            "message": "must not be blank"
-                                        }
+        @Test
+        @DataSet(value = "datasets/users.yml")
+        @Transactional
+        void 全てのユーザー取得できること() throws Exception {
+            mockMvc.perform(MockMvcRequestBuilders.get("/users"))
+                    .andExpect(MockMvcResultMatchers.status().isOk())
+                    //レスポンスボディの検証
+                    .andExpect(MockMvcResultMatchers.content().json(
+                            //text block便利！
+                            """
+                                    [
+                                         {
+                                             "id": 1,
+                                             "name": "yuichi",
+                                             "birthday": "1984-07-03"
+                                         },
+                                         {
+                                             "id": 2,
+                                             "name": "kana",
+                                             "birthday": "1993-12-31"
+                                         }
                                     ]
-                                }
-                                            """));
+                                    """
+                    ));
 
+        }
+
+        @Test
+        @DataSet(value = "datasets/users.yml")
+        @Transactional
+        void 指定したIDで存在するユーザーを取得すること() throws Exception {
+            mockMvc.perform(MockMvcRequestBuilders.get("/users/1"))
+                    .andExpect(MockMvcResultMatchers.status().isOk())
+
+                    .andExpect(MockMvcResultMatchers.content().json(
+                            //text block便利！
+                            """
+                                         {
+                                             "id": 1,
+                                             "name": "yuichi",
+                                             "birthday": "1984-07-03"
+                                         }
+                                    """
+                    ));
+        }
+
+        @Test
+        @DataSet(value = "datasets/users.yml")
+        @Transactional
+        void 指定した名前で存在するユーザーを取得すること() throws Exception {
+            mockMvc.perform(MockMvcRequestBuilders.get("/users/names?name=y"))
+                    .andExpect(MockMvcResultMatchers.status().isOk())
+                    .andExpect(MockMvcResultMatchers.content().json("""
+                                            {
+                                                     "id": 1,
+                                                     "name": "yuichi",
+                                                     "birthday": "1984-07-03"
+                                            }
+                            """
+                    ));
+        }
+
+        @Test
+        @DataSet(value = "datasets/users.yml")
+        @Transactional
+        void 存在しない名前を指定したとき例外処理を返すこと() throws Exception {
+
+            mockMvc.perform(MockMvcRequestBuilders.get("/users/names?name=unknownUser"))
+                    .andExpect(MockMvcResultMatchers.status().isNotFound())
+                    .andExpect(MockMvcResultMatchers.jsonPath("$.timestamp").exists())
+                    .andExpect(MockMvcResultMatchers.jsonPath("$.status").value("404"))
+                    .andExpect(MockMvcResultMatchers.jsonPath("$.error").value("Not Found"))
+                    .andExpect(MockMvcResultMatchers.jsonPath("$.message").value("user not found containing name: " + "unknownUser"))
+                    .andExpect(MockMvcResultMatchers.jsonPath("$.path").value("/users/names"));
+
+        }
+
+        @Test
+        @DataSet(value = "datasets/users.yml")
+        @Transactional
+        void 存在しないIDを指定したとき例外処理を返すこと() throws Exception {
+
+            mockMvc.perform(MockMvcRequestBuilders.get("/users/0"))
+                    .andExpect(MockMvcResultMatchers.status().isNotFound())
+                    .andExpect(MockMvcResultMatchers.jsonPath("$.timestamp").exists())
+                    .andExpect(MockMvcResultMatchers.jsonPath("$.status").value("404"))
+                    .andExpect(MockMvcResultMatchers.jsonPath("$.error").value("Not Found"))
+                    .andExpect(MockMvcResultMatchers.jsonPath("$.message").value("user not found with id: " + 0))
+                    .andExpect(MockMvcResultMatchers.jsonPath("$.path").value("/users/0"));
+
+        }
+    }
+
+
+    @Nested
+    class createClass {
+
+        @Test
+        @DataSet(value = "datasets/users.yml")
+        @ExpectedDataSet(value = "datasets/insertUsers.yml", ignoreCols = "id")
+        @Transactional
+        void 名前と生年月日を未使用のIDで紐づけし登録すること() throws Exception {
+            String requestBody = """
+                    {
+                               "name": "Tom",
+                               "birthday": "1990/01/01"
+                    }
+                    """;
+            mockMvc.perform(MockMvcRequestBuilders.post("/users")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(requestBody))
+                    .andExpect(MockMvcResultMatchers.status().isCreated())
+                    .andExpect(MockMvcResultMatchers.content().json("""
+                            {
+                                "message": "user created"
+                            }
+                            """));
+        }
+
+        @Test
+        @DataSet(value = "datasets/users.yml")
+        @Transactional
+        void 不正なフォーマットで登録しようとしたとき400エラーを返すこと() throws Exception {
+            String exceptionRequestBody = """
+                    {
+                               "name": "",
+                               "birthday": ""
+                    }
+                    """;
+            mockMvc.perform(MockMvcRequestBuilders.post("/users")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(exceptionRequestBody))
+                    .andExpect(MockMvcResultMatchers.status().isBadRequest())
+                    .andExpect(MockMvcResultMatchers.content().json(
+                            """
+                                    {
+                                        "status": "BAD_REQUEST",
+                                        "message": "validation error",
+                                        "errors": [
+                                            {
+                                                "field": "birthday",
+                                                "message": "YYYY/MM/ddで入力して下さい"
+                                            },
+                                            {
+                                                "field": "name",
+                                                "message": "must not be blank"
+                                            }
+                                        ]
+                                    }
+                                                """));
+
+        }
     }
 }

--- a/src/test/java/com/u1/user/integrationtest/UserIntegrationTest.java
+++ b/src/test/java/com/u1/user/integrationtest/UserIntegrationTest.java
@@ -92,7 +92,7 @@ public class UserIntegrationTest {
         @Test
         @DataSet(value = "datasets/users.yml")
         @Transactional
-        void 存在しない名前を指定したとき例外処理を返すこと() throws Exception {
+        void 存在しない名前を指定したとき404エラーを返すこと() throws Exception {
 
             mockMvc.perform(MockMvcRequestBuilders.get("/users/names?name=unknownUser"))
                     .andExpect(MockMvcResultMatchers.status().isNotFound())
@@ -107,7 +107,7 @@ public class UserIntegrationTest {
         @Test
         @DataSet(value = "datasets/users.yml")
         @Transactional
-        void 存在しないIDを指定したとき例外処理を返すこと() throws Exception {
+        void 存在しないIDを指定したとき404エラーを返すこと() throws Exception {
 
             mockMvc.perform(MockMvcRequestBuilders.get("/users/0"))
                     .andExpect(MockMvcResultMatchers.status().isNotFound())

--- a/src/test/java/com/u1/user/mapper/UserMapperTest.java
+++ b/src/test/java/com/u1/user/mapper/UserMapperTest.java
@@ -1,11 +1,13 @@
 package com.u1.user.mapper;
 
+import com.github.database.rider.core.api.dataset.DataSet;
+import com.github.database.rider.core.api.dataset.ExpectedDataSet;
+import com.github.database.rider.spring.api.DBRider;
 import com.u1.user.entity.User;
 import org.junit.jupiter.api.Test;
 import org.mybatis.spring.boot.test.autoconfigure.MybatisTest;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
-import org.springframework.test.context.jdbc.Sql;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
@@ -13,35 +15,36 @@ import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+@DBRider
 @MybatisTest
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 class UserMapperTest {
 
     @Autowired
     UserMapper userMapper;
-
+/*----------------------------Spring Test(@sql)verノート用-----------------------------------------------
     @Test
     @Sql(
             scripts = {"classpath:/sqlannotation/delete-users.sql", "classpath:/sqlannotation/insert-users.sql"},
             executionPhase = Sql.ExecutionPhase.BEFORE_TEST_METHOD
-    )
+   )
+    --------------------READ処理(GET)----------------------------------------------------------------*/
 
-    /*--------------------READ処理(GET)----------------------------------------------------------------*/
-
+    @Test
+    @DataSet(value = "datasets/users.yml")
     @Transactional
     void 全てのユーザーが取得できること() {
         List<User> users = userMapper.findAll();
         assertThat(users)
-                .hasSize(3)
+                .hasSize(2)
                 .contains(
                         new User(1, "yuichi", "1984-07-03"),
-                        new User(2, "kana", "1993-12-31"),
-                        new User(3, "tom", "1995-09-25")
+                        new User(2, "kana", "1993-12-31")
                 );
     }
 
     @Test
-
+    @DataSet(value = "datasets/users.yml")
     @Transactional
     void 指定したIDで存在するユーザーを取得すること() {
         Optional<User> user = userMapper.findById(1);
@@ -49,11 +52,21 @@ class UserMapperTest {
     }
 
     @Test
-
+    @DataSet(value = "datasets/users.yml")
     @Transactional
     void 指定した名前で存在するユーザーを取得すること() {
         Optional<User> user = userMapper.findByName("y");
         assertThat(user).contains(new User(1, "yuichi", "1984-07-03"));
     }
 
+
+    @Test
+    @DataSet(value = "datasets/users.yml")
+    @ExpectedDataSet(value = "datasets/insertUsers.yml", ignoreCols = "id")
+    @Transactional
+    void 名前と生年月日を紐づけしてIDで登録すること() {
+        User newUser = User.createUser("Tom", "1990-01-01");
+        userMapper.insert(newUser);
+    }
 }
+

--- a/src/test/java/com/u1/user/service/UserServiceTest.java
+++ b/src/test/java/com/u1/user/service/UserServiceTest.java
@@ -14,8 +14,7 @@ import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
 public class UserServiceTest {
@@ -73,5 +72,14 @@ public class UserServiceTest {
         });
 
     }
+
+    @Test
+    void 名前と生年月日を紐づけて新規登録すること() {
+        User user = new User(null, "tom", "1990-01-01");
+        doNothing().when(userMapper).insert(user);
+        assertThat(userService.insert("tom", "1990-01-01")).isEqualTo(user);
+        verify(userMapper).insert(user);
+    }
+
 
 }

--- a/src/test/resources/datasets/insertUsers.yml
+++ b/src/test/resources/datasets/insertUsers.yml
@@ -1,0 +1,11 @@
+users:
+  - id: 1
+    name: "yuichi"
+    birthday: "1984-07-03"
+  - id: 2
+    name: "kana"
+    birthday: "1993-12-31"
+  - id: 3
+    name: "Tom"
+    birthday: "1990-01-01"
+


### PR DESCRIPTION
# 概要
## CREATE処理の単体テスト・DBテスト・結合テストを実装しました。

* DBRiderを全てのテストに実装。
（統一を図りたかった点と使いやすかった為。）
* 名前と生年月日を紐づけて新規登録すること（単体・DB・結合）
* 指定しないフォーマットで登録しようとしたとき例外処理を返すこと（結合）
*** 

## DBRiderの実装

### @ DBRiderアノテーションを付与

resources/datasets/usres.ymlとinsertUsers.ymlファイルを作成

<img width="1000" alt="スクリーンショット 2024-05-07 22 40 10" src="https://github.com/u-

### resources/datasets/usres.ymlとinsertUsers.ymlファイルを作成

<img width="300" alt="スクリーンショット 2024-05-07 22 46 22" src="https://github.com/u-1pena/assignment10/assets/137189883/b97a2f9d-c6fe-4155-94ab-e670a176e3c3">

<img width="1134" alt="スクリーンショット 2024-05-07 22 48 57" src="https://github.com/u-1pena/assignment10/assets/137189883/94d38232-be89-40d3-9daf-af30d51594b4">

<img width="1131" alt="スクリーンショット 2024-05-07 22 49 23" src="https://github.com/u-1pena/assignment10/assets/137189883/2500c8eb-5217-4f66-94af-6809fbb20e96">

### 単体テスト
https://github.com/u-1pena/assignment10/blob/2ba33782947e7bac192d149db39a2c54e8286445/src/test/java/com/u1/user/service/UserServiceTest.java#L76-L82

### DBテスト
https://github.com/u-1pena/assignment10/blob/2ba33782947e7bac192d149db39a2c54e8286445/src/test/java/com/u1/user/mapper/UserMapperTest.java#L63-L70

### 結合テスト
https://github.com/u-1pena/assignment10/blob/2ba33782947e7bac192d149db39a2c54e8286445/src/test/java/com/u1/user/integrationtest/UserIntegrationTest.java#L118-L174


