### PR TITLE
DELETE処理のテストを実装

### DIFF
--- a/src/test/java/com/u1/user/integrationtest/UserIntegrationTest.java
+++ b/src/test/java/com/u1/user/integrationtest/UserIntegrationTest.java
@@ -207,7 +207,7 @@ public class UserIntegrationTest {
         @Test
         @DataSet(value = "datasets/users.yml")
         @Transactional
-        void 存在しないIDでユーザーを削除を行おうとしたとき404エラーを返すこと() throws Exception {
+        void 存在しないIDでユーザーの削除を行おうとしたとき404エラーを返すこと() throws Exception {
             mockMvc.perform(MockMvcRequestBuilders.delete("/users/0"))
                     .andExpect(MockMvcResultMatchers.status().isNotFound())
                     .andExpect(MockMvcResultMatchers.jsonPath("$.timestamp").exists())

--- a/src/test/java/com/u1/user/integrationtest/UserIntegrationTest.java
+++ b/src/test/java/com/u1/user/integrationtest/UserIntegrationTest.java
@@ -180,4 +180,22 @@ public class UserIntegrationTest {
 
         }
     }
+
+    @Nested
+    class deleteClass {
+
+        @Test
+        @DataSet(value = "datasets/users.yml")
+        @ExpectedDataSet(value = "datasets/deleteusers.yml")
+        @Transactional
+        void 指定したIDと紐づいた存在するユーザーを削除すること() throws Exception {
+            mockMvc.perform(MockMvcRequestBuilders.delete("/users/1"))
+                    .andExpect(MockMvcResultMatchers.status().isOk())
+                    .andExpect(MockMvcResultMatchers.content().json("""
+                            {
+                                "message": "a deleted user!"
+                            }
+                            """));
+        }
+    }
 }

--- a/src/test/java/com/u1/user/integrationtest/UserIntegrationTest.java
+++ b/src/test/java/com/u1/user/integrationtest/UserIntegrationTest.java
@@ -5,6 +5,8 @@ import com.github.database.rider.core.api.dataset.ExpectedDataSet;
 import com.github.database.rider.spring.api.DBRider;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
@@ -16,6 +18,7 @@ import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
 import org.springframework.transaction.annotation.Transactional;
 
 @SpringBootTest//結合テストがメインで使われる// ！単体だと非効率！！
+@ExtendWith(MockitoExtension.class)
 @AutoConfigureMockMvc
 @DBRider
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
@@ -186,9 +189,10 @@ public class UserIntegrationTest {
 
         @Test
         @DataSet(value = "datasets/users.yml")
-        @ExpectedDataSet(value = "datasets/deleteusers.yml")
+        @ExpectedDataSet(value = "datasets/deleteUsers.yml")
         @Transactional
         void 指定したIDと紐づいた存在するユーザーを削除すること() throws Exception {
+
             mockMvc.perform(MockMvcRequestBuilders.delete("/users/1"))
                     .andExpect(MockMvcResultMatchers.status().isOk())
                     .andExpect(MockMvcResultMatchers.content().json("""
@@ -196,6 +200,8 @@ public class UserIntegrationTest {
                                 "message": "a deleted user!"
                             }
                             """));
+
+
         }
     }
 }

--- a/src/test/java/com/u1/user/integrationtest/UserIntegrationTest.java
+++ b/src/test/java/com/u1/user/integrationtest/UserIntegrationTest.java
@@ -25,7 +25,7 @@ public class UserIntegrationTest {
     MockMvc mockMvc;
 
     @Nested
-    class readClass {
+    class ReadClass {
 
         @Test
         @DataSet(value = "datasets/users.yml")
@@ -122,7 +122,7 @@ public class UserIntegrationTest {
 
 
     @Nested
-    class createClass {
+    class CreateClass {
 
         @Test
         @DataSet(value = "datasets/users.yml")
@@ -182,7 +182,7 @@ public class UserIntegrationTest {
     }
 
     @Nested
-    class deleteClass {
+    class DeleteClass {
 
         @Test
         @DataSet(value = "datasets/users.yml")
@@ -196,6 +196,20 @@ public class UserIntegrationTest {
                                 "message": "a deleted user!"
                             }
                             """));
+        }
+
+        @Test
+        @DataSet(value = "datasets/users.yml")
+        @Transactional
+        void 存在しないIDでユーザーを削除を行おうとしたとき404エラーを返すこと() throws Exception {
+            mockMvc.perform(MockMvcRequestBuilders.delete("/users/0"))
+                    .andExpect(MockMvcResultMatchers.status().isNotFound())
+                    .andExpect(MockMvcResultMatchers.jsonPath("$.timestamp").exists())
+                    .andExpect(MockMvcResultMatchers.jsonPath("$.status").value("404"))
+                    .andExpect(MockMvcResultMatchers.jsonPath("$.error").value("Not Found"))
+                    .andExpect(MockMvcResultMatchers.jsonPath("$.message").value("user not found with id: " + 0))
+                    .andExpect(MockMvcResultMatchers.jsonPath("$.path").value("/users/0"));
+
         }
     }
 }

--- a/src/test/java/com/u1/user/mapper/UserMapperTest.java
+++ b/src/test/java/com/u1/user/mapper/UserMapperTest.java
@@ -4,6 +4,7 @@ import com.github.database.rider.core.api.dataset.DataSet;
 import com.github.database.rider.core.api.dataset.ExpectedDataSet;
 import com.github.database.rider.spring.api.DBRider;
 import com.u1.user.entity.User;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.mybatis.spring.boot.test.autoconfigure.MybatisTest;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -30,43 +31,64 @@ class UserMapperTest {
    )
     --------------------READ処理(GET)----------------------------------------------------------------*/
 
-    @Test
-    @DataSet(value = "datasets/users.yml")
-    @Transactional
-    void 全てのユーザーが取得できること() {
-        List<User> users = userMapper.findAll();
-        assertThat(users)
-                .hasSize(2)
-                .contains(
-                        new User(1, "yuichi", "1984-07-03"),
-                        new User(2, "kana", "1993-12-31")
-                );
+    @Nested
+    class readClass {
+
+        @Test
+        @DataSet(value = "datasets/users.yml")
+        @Transactional
+        void 全てのユーザーが取得できること() {
+            List<User> users = userMapper.findAll();
+            assertThat(users)
+                    .hasSize(2)
+                    .contains(
+                            new User(1, "yuichi", "1984-07-03"),
+                            new User(2, "kana", "1993-12-31")
+                    );
+        }
+
+        @Test
+        @DataSet(value = "datasets/users.yml")
+        @Transactional
+        void 指定したIDで存在するユーザーを取得すること() {
+            Optional<User> user = userMapper.findById(1);
+            assertThat(user).contains(new User(1, "yuichi", "1984-07-03"));
+        }
+
+        @Test
+        @DataSet(value = "datasets/users.yml")
+        @Transactional
+        void 指定した名前で存在するユーザーを取得すること() {
+            Optional<User> user = userMapper.findByName("y");
+            assertThat(user).contains(new User(1, "yuichi", "1984-07-03"));
+        }
+
     }
 
-    @Test
-    @DataSet(value = "datasets/users.yml")
-    @Transactional
-    void 指定したIDで存在するユーザーを取得すること() {
-        Optional<User> user = userMapper.findById(1);
-        assertThat(user).contains(new User(1, "yuichi", "1984-07-03"));
+
+    @Nested
+    class createClass {
+        @Test
+        @DataSet(value = "datasets/users.yml")
+        @ExpectedDataSet(value = "datasets/insertUsers.yml", ignoreCols = "id")
+        @Transactional
+        void 名前と生年月日を紐づけしてIDで登録すること() {
+            User newUser = User.createUser("Tom", "1990-01-01");
+            userMapper.insert(newUser);
+        }
     }
 
-    @Test
-    @DataSet(value = "datasets/users.yml")
-    @Transactional
-    void 指定した名前で存在するユーザーを取得すること() {
-        Optional<User> user = userMapper.findByName("y");
-        assertThat(user).contains(new User(1, "yuichi", "1984-07-03"));
-    }
+    @Nested
+    class deleteClas {
 
+        @Test
+        @DataSet(value = "datasets/users.yml")
+        @ExpectedDataSet(value = "datasets/deleteUsers.yml")
+        @Transactional
+        void 指定したIDに紐づいた存在するユーザーを削除すること() {
+            userMapper.delete(1);
+        }
 
-    @Test
-    @DataSet(value = "datasets/users.yml")
-    @ExpectedDataSet(value = "datasets/insertUsers.yml", ignoreCols = "id")
-    @Transactional
-    void 名前と生年月日を紐づけしてIDで登録すること() {
-        User newUser = User.createUser("Tom", "1990-01-01");
-        userMapper.insert(newUser);
     }
 }
 

--- a/src/test/java/com/u1/user/mapper/UserMapperTest.java
+++ b/src/test/java/com/u1/user/mapper/UserMapperTest.java
@@ -32,7 +32,7 @@ class UserMapperTest {
     --------------------READ処理(GET)----------------------------------------------------------------*/
 
     @Nested
-    class readClass {
+    class ReadClass {
 
         @Test
         @DataSet(value = "datasets/users.yml")
@@ -67,7 +67,7 @@ class UserMapperTest {
 
 
     @Nested
-    class createClass {
+    class CreateClass {
         @Test
         @DataSet(value = "datasets/users.yml")
         @ExpectedDataSet(value = "datasets/insertUsers.yml", ignoreCols = "id")
@@ -79,7 +79,7 @@ class UserMapperTest {
     }
 
     @Nested
-    class deleteClas {
+    class DeleteClas {
 
         @Test
         @DataSet(value = "datasets/users.yml")

--- a/src/test/java/com/u1/user/service/UserServiceTest.java
+++ b/src/test/java/com/u1/user/service/UserServiceTest.java
@@ -26,7 +26,7 @@ public class UserServiceTest {
     UserMapper userMapper;
 
     @Nested
-    class readClass {
+    class ReadClass {
         @Test
         void 全てのユーザーが取得できること() {
             List<User> users = List.of(
@@ -79,7 +79,7 @@ public class UserServiceTest {
     }
 
     @Nested
-    class createClass {
+    class CreateClass {
         @Test
         void 名前と生年月日を紐づけて新規登録すること() {
             User user = new User(null, "tom", "1990-01-01");
@@ -90,7 +90,7 @@ public class UserServiceTest {
     }
 
     @Nested
-    class deleteClass {
+    class DeleteClass {
 
         @Test
         void 指定したIDに紐づいて登録されたユーザーを削除すること() {

--- a/src/test/java/com/u1/user/service/UserServiceTest.java
+++ b/src/test/java/com/u1/user/service/UserServiceTest.java
@@ -3,6 +3,7 @@ package com.u1.user.service;
 import com.u1.user.controller.response.UserNotFoundException;
 import com.u1.user.entity.User;
 import com.u1.user.mapper.UserMapper;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -24,62 +25,86 @@ public class UserServiceTest {
     @Mock
     UserMapper userMapper;
 
-    @Test
-    void 全てのユーザーが取得できること() {
-        List<User> users = List.of(
-                new User(1, "yuichi", "1984-07-03"),
-                new User(2, "kana", "1993-12-31"),
-                new User(3, "tom", "1995-09-25")
-        );
+    @Nested
+    class readClass {
+        @Test
+        void 全てのユーザーが取得できること() {
+            List<User> users = List.of(
+                    new User(1, "yuichi", "1984-07-03"),
+                    new User(2, "kana", "1993-12-31"),
+                    new User(3, "tom", "1995-09-25")
+            );
 
-        doReturn(users).when(userMapper).findAll();
-        List<User> actual = userService.findAll();
-        assertThat(actual).isEqualTo(users);
-        verify(userMapper).findAll();
+            doReturn(users).when(userMapper).findAll();
+            List<User> actual = userService.findAll();
+            assertThat(actual).isEqualTo(users);
+            verify(userMapper).findAll();
+        }
+
+        @Test
+        void 指定したIDで存在するユーザーを取得すること() {
+            doReturn(Optional.of(new User(1, "yuichi", "1984-07-03"))).when(userMapper).findById(1);
+            User actual = userService.findUser(1);
+            assertThat(actual).isEqualTo(new User(1, "yuichi", "1984-07-03"));
+            verify(userMapper).findById(1);
+        }
+
+        @Test
+        void 存在しないIDを指定したとき例外処理を返すこと() throws UserNotFoundException {
+            doReturn(Optional.empty()).when(userMapper).findById(0);
+            assertThrows(UserNotFoundException.class, () -> {
+                userService.findUser(0);
+            });
+
+        }
+
+        @Test
+        void 指定した名前で存在するユーザーを取得すること() {
+            doReturn(Optional.of(new User(1, "yuichi", "1984-07-03"))).when(userMapper).findByName("yuichi");
+            User actual = userService.findByName("yuichi");
+            assertThat(actual).isEqualTo(new User(1, "yuichi", "1984-07-03"));
+            verify(userMapper).findByName("yuichi");
+
+        }
+
+        @Test
+        void 存在しない名前を指定したとき例外処理を返すこと() throws UserNotFoundException {
+            doReturn(Optional.empty()).when(userMapper).findByName("tarou");
+            assertThrows(UserNotFoundException.class, () -> {
+                userService.findByName("tarou");
+            });
+
+        }
+
     }
 
-    @Test
-    void 指定したIDで存在するユーザーを取得すること() {
-        doReturn(Optional.of(new User(1, "yuichi", "1984-07-03"))).when(userMapper).findById(1);
-        User actual = userService.findUser(1);
-        assertThat(actual).isEqualTo(new User(1, "yuichi", "1984-07-03"));
-        verify(userMapper).findById(1);
+    @Nested
+    class createClass {
+        @Test
+        void 名前と生年月日を紐づけて新規登録すること() {
+            User user = new User(null, "tom", "1990-01-01");
+            doNothing().when(userMapper).insert(user);
+            assertThat(userService.insert("tom", "1990-01-01")).isEqualTo(user);
+            verify(userMapper).insert(user);
+        }
     }
 
-    @Test
-    void 存在しないIDを指定したとき例外処理を返すこと() throws UserNotFoundException {
-        doReturn(Optional.empty()).when(userMapper).findById(0);
-        assertThrows(UserNotFoundException.class, () -> {
-            userService.findUser(0);
-        });
+    @Nested
+    class deleteClass {
+
+        @Test
+        void 指定したIDに紐づいて登録されたユーザーを削除すること() {
+            doReturn(Optional.of(new User(1, "yuichi", "1984-07-03"))).when(userMapper).findById(1);
+            User actual = userService.delete(1);
+            assertThat(actual).isEqualTo(new User(1, "yuichi", "1984-07-03"));
+            verify(userMapper).findById(1);
+            verify(userMapper).delete(1);
+        }
+
+        //IDが存在しない場合の例外処理はreadClassの「存在しないIDを指定したとき例外処理を返すこと」と同じなので割愛
+
 
     }
-
-    @Test
-    void 指定した名前で存在するユーザーを取得すること() {
-        doReturn(Optional.of(new User(1, "yuichi", "1984-07-03"))).when(userMapper).findByName("yuichi");
-        User actual = userService.findByName("yuichi");
-        assertThat(actual).isEqualTo(new User(1, "yuichi", "1984-07-03"));
-        verify(userMapper).findByName("yuichi");
-
-    }
-
-    @Test
-    void 存在しない名前を指定したとき例外処理を返すこと() throws UserNotFoundException {
-        doReturn(Optional.empty()).when(userMapper).findByName("tarou");
-        assertThrows(UserNotFoundException.class, () -> {
-            userService.findByName("tarou");
-        });
-
-    }
-
-    @Test
-    void 名前と生年月日を紐づけて新規登録すること() {
-        User user = new User(null, "tom", "1990-01-01");
-        doNothing().when(userMapper).insert(user);
-        assertThat(userService.insert("tom", "1990-01-01")).isEqualTo(user);
-        verify(userMapper).insert(user);
-    }
-
 
 }
+

--- a/src/test/resources/datasets/deleteUsers.yml
+++ b/src/test/resources/datasets/deleteUsers.yml
@@ -1,0 +1,4 @@
+users:
+  - id: 2
+    name: "kana"
+    birthday: "1993-12-31"


### PR DESCRIPTION
# 概要
__DELETE処理に対して単体・DB・結合テストを実装しました。また、各テストを見やすくするためにNest化しました。__

* __単体テスト__

https://github.com/u-1pena/assignment10/blob/8b0c3c334a2985caa0edb66f9789cdb3b150bbe6/src/test/java/com/u1/user/service/UserServiceTest.java#L92-L107

* __DBテスト__

https://github.com/u-1pena/assignment10/blob/8b0c3c334a2985caa0edb66f9789cdb3b150bbe6/src/test/java/com/u1/user/mapper/UserMapperTest.java#L81-L90

* __結合テスト__

https://github.com/u-1pena/assignment10/blob/8b0c3c334a2985caa0edb66f9789cdb3b150bbe6/src/test/java/com/u1/user/integrationtest/UserIntegrationTest.java#L187-L206


deleteUsers.ymlファイルがタイポしていた為、失敗。
修正致しました。

<img width="835" alt="スクリーンショット 2024-05-10 8 45 48" src="https://github.com/u-1pena/assignment10/assets/137189883/5a0d4072-87a3-40f8-9df2-4827c5dd3221">

https://github.com/u-1pena/assignment10/pull/15/commits/8b0c3c334a2985caa0edb66f9789cdb3b150bbe6

